### PR TITLE
Adding 'event' to functions so it work in Firefox

### DIFF
--- a/js/acf5_repeater_collapser_admin.js
+++ b/js/acf5_repeater_collapser_admin.js
@@ -133,7 +133,7 @@ jQuery(document).ready(function($) {
 	/**
 	 * toggles set of repeater rows or flexible fields
 	 */
-	function acfRepeaterToggleAll() {
+	function acfRepeaterToggleAll(event) {
 		$rowsetButton = $(this);
 		$rowsetWrapper = $(this).closest('.acf-field');
 
@@ -160,7 +160,7 @@ jQuery(document).ready(function($) {
 	/**
 	 * toggles single repeater row or flexible field
 	 */
-	function acfRepeaterToggleSingle() {
+	function acfRepeaterToggleSingle(event) {
 		$rowButton = $(this);
 		$rowButtonText = $('.screen-reader-text', $rowButton);
 		$row = $rowButton.closest('.acf-row,.layout');


### PR DESCRIPTION
Without the 'event' in the function call it doesn't work in Firefox
