### PR TITLE
Update classes for ACF > 5.2.7

### DIFF
--- a/css/acf5_repeater_collapser_admin.css
+++ b/css/acf5_repeater_collapser_admin.css
@@ -24,23 +24,23 @@
 	position: relative;
 }
 
-.field_type-flexible_content .layout.row-layout {
+.acf-field-flexible-content .layout.row-layout {
 	padding-left: 30px;
 	background: transparent;
 }
 
-.field_type-flexible_content .field-repeater-toggle-single {
+.acf-field-flexible-content .field-repeater-toggle-single {
 	position: absolute;
 	top: 50%;
 	margin-top: -15px;
 	left: 5px;
 }
 /* Weird positioning exception */
-.field_type-flexible_content .field_type-repeater .field-repeater-toggle-single {
+.acf-field-flexible-content .acf-field-repeater .field-repeater-toggle-single {
 	left: 8px;
 }
 
-.field_type-flexible_content .acf-fc-layout-handle {
+.acf-field-flexible-content .acf-fc-layout-handle {
 	background: #fff;
 }
 

--- a/js/acf5_repeater_collapser_admin.js
+++ b/js/acf5_repeater_collapser_admin.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($) {
 		$collapseSingleButton = '<button type="button" role="button" class="button field-repeater-toggle field-repeater-toggle-single"><span class="screen-reader-text">Collapse Row</span></button>';
 
 		// find each repeater & flexible instance, add the button if the field uses the row layout
-		$('.field_type-repeater, .field_type-flexible_content').each( function() {
+		$('.acf-field-repeater, .acf-field-flexible-content').each( function() {
 			$repeater = $(this);
 
 			// only use this on row layout
@@ -35,7 +35,7 @@ jQuery(document).ready(function($) {
 		// iterator for adding IDs/aria-controls attributes to repeater buttons
 		i = 1;
 		// append single repeater collapse to each row of repeater field
-		$('.field_type-repeater .row-layout > tbody > .acf-row,.field_type-repeater > tbody > .row-layout .acf-row.clone').each( function() {
+		$('.acf-field-repeater .row-layout > tbody > .acf-row,.acf-field-repeater > tbody > .row-layout .acf-row.clone').each( function() {
 			id = 'acf-repeater-' + i;
 
 			$(this).prepend( $collapseSingleButtonTable )
@@ -50,7 +50,7 @@ jQuery(document).ready(function($) {
 		});
 
 		// append single repeater collapse to flex fields
-		$('.field_type-flexible_content .layout').each( function() {
+		$('.acf-field-flexible-content .layout').each( function() {
 			if( $('.acf-input-table', $(this)).hasClass('row-layout') ) {
 				id = 'acf-repeater-' + i;
 				i++;
@@ -68,19 +68,19 @@ jQuery(document).ready(function($) {
 
 		// Bind click events to the toggle functions
 		// delegated to higher DOM element to handle dynamically added repeaters
-		$( '.field_type-repeater, .field_type-flexible_content' ).on(
+		$( '.acf-field-repeater, .acf-field-flexible-content' ).on(
 			'click',
 			'.field-repeater-toggle-all',
 			acfRepeaterToggleAll
 		);
-		$( '.field_type-repeater .row-layout,.field_type-flexible_content' ).on(
+		$( '.acf-field-repeater .row-layout,.acf-field-flexible-content' ).on(
 			'click',
 			'.field-repeater-toggle-single',
 			acfRepeaterToggleSingle
 		);
 
 		// prevent default flexible field collapsing for clarity
-		$('.field_type-flexible_content').on(
+		$('.acf-field-flexible-content').on(
 			'click',
 			'.acf-fc-layout-handle',
 			false


### PR DESCRIPTION
from `.field_type-repeater` to `.acf-field-repeater`
from `.field_type-flexible_content` to `.acf-field-flexible-content`

should fix https://github.com/mrwweb/ACF-Repeater-Collapser/issues/30