### PR TITLE
Default functionality update

### DIFF
--- a/js/acf4_repeater_collapser_admin.js
+++ b/js/acf4_repeater_collapser_admin.js
@@ -165,7 +165,9 @@ jQuery(document).ready(function($) {
 		}
 
 		// prevent bubbling up to parent repeater rowset
-		event.stopPropagation();
+		if (event) {
+			event.stopPropagation();
+		}
 	}
 
 	/**

--- a/js/acf4_repeater_collapser_admin.js
+++ b/js/acf4_repeater_collapser_admin.js
@@ -11,6 +11,10 @@ jQuery(document).ready(function($) {
 			$collapseSingleButtonTable = '<td class="repeater-button-cell"><div class="repeater-button-cell-div"><button type="button" role="button" class="button field-repeater-toggle field-repeater-toggle-single"><span class="screen-reader-text">' + acfrcL10n.collapseRow + '</span></button></div></td>',
 			$collapseSingleButton = '<button type="button" role="button" class="button field-repeater-toggle field-repeater-toggle-single"><span class="screen-reader-text">' + acfrcL10n.collapseRow + '</span></button>';
 
+			// Collapse all fields by default
+			acfRepeaterToggleAll();
+
+
 		// find each repeater & flexible instance, add the button if the field uses the row layout
 		$('.field_type-repeater, .field_type-flexible_content').each( function() {
 			var	$repeater = $(this);
@@ -137,6 +141,13 @@ jQuery(document).ready(function($) {
 			$rowsetButton  = $that,
 			$rowsetWrapper = $that.parent();
 
+			if ($rowsetWrapper.length == 0) {
+				$rowsetWrapper = $('.field_type-repeater');
+			}
+			else {
+				$rowsetWrapper = $that.parent();
+			}
+
 		// select either nested or unnested repeater rows, not both
 		if( true === $rowsetWrapper.data('acf-repeater-nested') ) {
 			$rows = $('.row:data(acf-repeater-nested),.layout', $rowsetWrapper);
@@ -187,7 +198,9 @@ jQuery(document).ready(function($) {
 		}
 
 		// prevent bubbling up to parent row button
-		event.stopPropagation();
+		if (event) {
+			event.stopPropagation();
+		}
 	}
 
 	/**

--- a/js/acf5_repeater_collapser_admin.js
+++ b/js/acf5_repeater_collapser_admin.js
@@ -11,6 +11,9 @@ jQuery(document).ready(function($) {
 			$collapseSingleButtonTable = '<td class="repeater-button-cell"><div class="repeater-button-cell-div"><button type="button" role="button" class="button field-repeater-toggle field-repeater-toggle-single"><span class="screen-reader-text">' + acfrcL10n.collapseRow + '</span></button></div></td>',
 			$collapseSingleButton = '<button type="button" role="button" class="button field-repeater-toggle field-repeater-toggle-single"><span class="screen-reader-text">' + acfrcL10n.collapseRow + '</span></button>';
 
+			// Collapse all fields by default
+			acfRepeaterToggleAll();
+			
 		// find each repeater & flexible instance, add the button if the field uses the row layout
 		$('.field_type-repeater, .field_type-flexible_content').each( function() {
 			var $repeater = $(this);
@@ -143,6 +146,13 @@ jQuery(document).ready(function($) {
 			$rowsetButton  = $that,
 			$rowsetWrapper = $that.closest('.acf-field');
 
+			if ($rowsetWrapper.length == 0) {
+				$rowsetWrapper = $('.field_type-repeater');
+			}
+			else {
+				$rowsetWrapper = $that.parent();
+			}
+
 		// select either nested or unnested repeater rows, not both
 		if( true === $rowsetWrapper.data('acf-repeater-nested') ) {
 			$rows = $('.acf-row:data(acf-repeater-nested),.layout', $rowsetWrapper);
@@ -186,7 +196,9 @@ jQuery(document).ready(function($) {
 		}
 
 		// prevent bubbling up to parent row button
-		event.stopPropagation();
+		if (event) {
+			event.stopPropagation();
+		}
 	}
 
 	/**

--- a/js/acf5_repeater_collapser_admin.js
+++ b/js/acf5_repeater_collapser_admin.js
@@ -170,7 +170,9 @@ jQuery(document).ready(function($) {
 		}
 
 		// prevent bubbling up to parent repeater rowset
-		event.stopPropagation();
+		if (event) {
+            event.stopPropagation();
+        }
 	}
 
 	/**


### PR DESCRIPTION
As I use acf repeater quite a lot and have many repeater fields per page, I have added functionality to have all rows collapsed by default.

Not sure if helpful to your project but I thought I would create a pull request anyway if you're interested. 