### PR TITLE
Update acf5_repeater_collapser_admin.css

### DIFF
--- a/css/acf5_repeater_collapser_admin.css
+++ b/css/acf5_repeater_collapser_admin.css
@@ -1,8 +1,8 @@
 .collapse { 
 	box-sizing: border-box;
 	position: absolute;
-	top:15px;
-	right:12px;
+	top: 0;
+	right: 0;
 	border:1px solid #d1d1d1;
 	background:#FFF;
 	font-weight:normal;


### PR DESCRIPTION
Top and right are causing problems with nested repeater fields. Setting them to 0 resolves cutting of the clickable button.